### PR TITLE
Add provider specifying example to rails guide

### DIFF
--- a/docs/guides/rails.md
+++ b/docs/guides/rails.md
@@ -195,6 +195,28 @@ class ToolCall < ApplicationRecord
 end
 ```
 
+### Use Alternate Providers 
+
+You can always specify the provider-specific model id. But if you want to use aliases, one approach is to set the chat instance variable in an after_initialize callback:
+
+```ruby
+ class Chat < ApplicationRecord
+    acts_as_chat
+
+    validates :model_id, presence: true
+    validates :provider, presence: true
+
+    after_initialize :set_chat
+
+    def set_chat
+      @chat = RubyLLM::Chat.new(model: model_id, provider:)
+    end
+  end
+
+  Chat.new(model_id: 'alias', provider: 'provider_name')
+```
+
+
 ## Basic Usage
 
 Once your models are set up, the `acts_as_chat` helper delegates common `RubyLLM::Chat` methods to your `Chat` model:


### PR DESCRIPTION
## What this does

Provide similar example that answered #226

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ X] Documentation
- [ ] Performance improvement

## Scope check

- [X ] I read the [Contributing Guide](https://github.com/crmne/ruby_llm/blob/main/CONTRIBUTING.md)
- [X] This aligns with RubyLLM's focus on **LLM communication**
- [X] This isn't application-specific logic that belongs in user code
- [X] This benefits most users, not just my specific use case

## Quality check

- [X] I ran `overcommit --install` and all hooks pass
- [X] I tested my changes thoroughly
- [X] I updated documentation if needed
- [X] I didn't modify auto-generated files manually (`models.json`, `aliases.json`)

## API changes

- [ ] Breaking change
- [ ] New public methods/classes
- [ ] Changed method signatures
- [X] No API changes

## Related issues

<!-- Link issues: "Fixes #123" or "Related to #123" -->
Related to #226